### PR TITLE
feat(qa): add Playwright E2E tests for auth and applications

### DIFF
--- a/MPI-Project/frontend/.gitignore
+++ b/MPI-Project/frontend/.gitignore
@@ -22,3 +22,10 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
+/playwright/.auth/

--- a/MPI-Project/frontend/e2e/applications-list.spec.ts
+++ b/MPI-Project/frontend/e2e/applications-list.spec.ts
@@ -1,0 +1,150 @@
+import { test, expect } from '@playwright/test';
+
+const TIMESTAMP = Date.now();
+const TEST_USER = {
+  fullName: 'List Test User',
+  email: `listtest_${TIMESTAMP}@example.com`,
+  password: 'Password123',
+};
+
+test.describe('Applications List Flow', () => {
+  test.beforeAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    // inregistrare
+    await page.goto('/register');
+    await page.getByLabel('Full name').fill(TEST_USER.fullName);
+    await page.getByLabel('Email').fill(TEST_USER.email);
+    await page.getByLabel('Password', { exact: true }).fill(TEST_USER.password);
+    await page.getByLabel('Confirm password').fill(TEST_USER.password);
+    await page.getByRole('button', { name: 'Create account' }).click();
+    await page.locator('.auth-message-success').waitFor();
+    // login
+    await page.goto('/login');
+    await page.getByLabel('Email').fill(TEST_USER.email);
+    await page.getByLabel('Password').fill(TEST_USER.password);
+    await page.getByRole('button', { name: 'Login' }).click();
+    await expect(page).toHaveURL('/');
+    // cream aplicatie cu status INTERVIEW
+    await page.goto('/applications/new');
+    await page.getByLabel('Company name').fill('Google');
+    await page.getByLabel('Role').fill('Software Engineer');
+    await page.getByLabel('Status').selectOption('INTERVIEW');
+    await page.getByLabel('Application date').fill('2026-04-14');
+    await page.getByRole('button', { name: 'Save application' }).click();
+    await expect(page).toHaveURL('/');
+    // cream aplicatie cu status APPLIED
+    await page.goto('/applications/new');
+    await page.getByLabel('Company name').fill('Amazon');
+    await page.getByLabel('Role').fill('Backend Developer');
+    await page.getByLabel('Status').selectOption('APPLIED');
+    await page.getByLabel('Application date').fill('2026-04-10');
+    await page.getByRole('button', { name: 'Save application' }).click();
+    await expect(page).toHaveURL('/');
+    await page.close();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/login');
+    await page.getByLabel('Email').fill(TEST_USER.email);
+    await page.getByLabel('Password').fill(TEST_USER.password);
+    await page.getByRole('button', { name: 'Login' }).click();
+    await expect(page).toHaveURL('/');
+  });
+
+  // TC1
+  test('TC1 - applications list page loads successfully', async ({ page }) => {
+    await expect(page.locator('.applications-table, .applications-state')).toBeVisible();
+  });
+
+  // TC2 + TC3
+  test('TC2/TC3 - displays correct application data', async ({ page }) => {
+    await expect(page.getByText('Google')).toBeVisible();
+    await expect(page.getByText('Software Engineer')).toBeVisible();
+    await expect(page.locator('.status-pill.status-interview')).toBeVisible();
+  });
+
+  // TC4 - empty state
+  test('TC4 - empty state shown when no applications exist', async ({ browser }) => {
+    const emptyEmail = `empty_${TIMESTAMP}@example.com`;
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await page.goto('/register');
+    await page.getByLabel('Full name').fill('Empty User');
+    await page.getByLabel('Email').fill(emptyEmail);
+    await page.getByLabel('Password', { exact: true }).fill('Password123');
+    await page.getByLabel('Confirm password').fill('Password123');
+    await page.getByRole('button', { name: 'Create account' }).click();
+    await page.locator('.auth-message-success').waitFor();
+    await page.goto('/login');
+    await page.getByLabel('Email').fill(emptyEmail);
+    await page.getByLabel('Password').fill('Password123');
+    await page.getByRole('button', { name: 'Login' }).click();
+    await expect(page).toHaveURL('/');
+
+    await expect(page.locator('.applications-state')).toContainText('No applications yet');
+    await context.close();
+  });
+
+  // TC7 - unauthenticated redirect
+  test('TC7 - unauthenticated user is redirected to login', async ({ browser }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await page.goto('/');
+    await expect(page).toHaveURL('/login');
+    await context.close();
+  });
+
+  // TC8 - data isolation
+  test('TC8 - user sees only their own applications', async ({ browser }) => {
+    const otherEmail = `other_${TIMESTAMP}@example.com`;
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await page.goto('/register');
+    await page.getByLabel('Full name').fill('Other User');
+    await page.getByLabel('Email').fill(otherEmail);
+    await page.getByLabel('Password', { exact: true }).fill('Password123');
+    await page.getByLabel('Confirm password').fill('Password123');
+    await page.getByRole('button', { name: 'Create account' }).click();
+    await page.locator('.auth-message-success').waitFor();
+    await page.goto('/login');
+    await page.getByLabel('Email').fill(otherEmail);
+    await page.getByLabel('Password').fill('Password123');
+    await page.getByRole('button', { name: 'Login' }).click();
+    await expect(page).toHaveURL('/');
+
+    await expect(page.getByText('Google')).not.toBeVisible();
+    await context.close();
+  });
+
+  // TC13 - filter by status
+  test('TC13 - filter by status shows only matching applications', async ({ page }) => {
+    await page.getByLabel('Filter by status').selectOption('INTERVIEW');
+    await expect(page.getByText('Google')).toBeVisible();
+
+    await page.getByLabel('Filter by status').selectOption('OFFER');
+    await expect(page.locator('.applications-state')).toBeVisible();
+  });
+
+  // FILTER1 - filter APPLIED
+  test('FILTER1 - filter by APPLIED shows only applied applications', async ({ page }) => {
+    await page.locator('.applications-table').waitFor();
+    await page.getByLabel('Filter by status').selectOption('APPLIED');
+    await expect(page.locator('.status-pill.status-applied')).toBeVisible();
+    await expect(page.locator('.status-pill.status-interview')).not.toBeVisible();
+  });
+
+  // FILTER2 - filter ALL arata toate aplicatiile
+  test('FILTER2 - filter by ALL shows all applications', async ({ page }) => {
+    await page.locator('.applications-table').waitFor();
+    await page.getByLabel('Filter by status').selectOption('INTERVIEW');
+    await page.getByLabel('Filter by status').selectOption('ALL');
+    await expect(page.locator('.status-pill.status-applied')).toBeVisible();
+    await expect(page.locator('.status-pill.status-interview')).toBeVisible();
+  });
+
+  // FILTER3 - filter fara rezultate afiseaza empty state
+  test('FILTER3 - filter with no results shows empty state message', async ({ page }) => {
+    await page.getByLabel('Filter by status').selectOption('OFFER');
+    await expect(page.locator('.applications-state')).toBeVisible();
+  });
+});

--- a/MPI-Project/frontend/e2e/create-application.spec.ts
+++ b/MPI-Project/frontend/e2e/create-application.spec.ts
@@ -1,0 +1,91 @@
+import { test, expect } from '@playwright/test';
+
+const TIMESTAMP = Date.now();
+const TEST_USER = {
+  fullName: 'Create App User',
+  email: `createapp_${TIMESTAMP}@example.com`,
+  password: 'Password123',
+};
+
+test.describe('Create Application Flow', () => {
+  test.beforeAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    await page.goto('/register');
+    await page.getByLabel('Full name').fill(TEST_USER.fullName);
+    await page.getByLabel('Email').fill(TEST_USER.email);
+    await page.getByLabel('Password', { exact: true }).fill(TEST_USER.password);
+    await page.getByLabel('Confirm password').fill(TEST_USER.password);
+    await page.getByRole('button', { name: 'Create account' }).click();
+    await page.locator('.auth-message-success').waitFor();
+    await page.close();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/login');
+    await page.getByLabel('Email').fill(TEST_USER.email);
+    await page.getByLabel('Password').fill(TEST_USER.password);
+    await page.getByRole('button', { name: 'Login' }).click();
+    await expect(page).toHaveURL('/');
+    await page.goto('/applications/new');
+  });
+
+  // TC1
+  test('TC1 - create application page loads with all fields', async ({ page }) => {
+    await expect(page.getByLabel('Company name')).toBeVisible();
+    await expect(page.getByLabel('Role')).toBeVisible();
+    await expect(page.getByLabel('Status')).toBeVisible();
+    await expect(page.getByLabel('Application date')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Save application' })).toBeVisible();
+  });
+
+  // TC2
+  test('TC2 - successful creation redirects to applications list', async ({ page }) => {
+    await page.getByLabel('Company name').fill('Google');
+    await page.getByLabel('Role').fill('Software Engineer');
+    await page.getByLabel('Application date').fill('2026-04-14');
+    await page.getByRole('button', { name: 'Save application' }).click();
+
+    await expect(page).toHaveURL('/');
+  });
+
+  // TC4 - status dropdown contine doar valori valide
+  test('TC4 - status dropdown contains only valid values', async ({ page }) => {
+    const options = page.getByLabel('Status').locator('option');
+    await expect(options).toHaveCount(4);
+    await expect(options.nth(0)).toHaveText('Applied');
+    await expect(options.nth(1)).toHaveText('Interview');
+    await expect(options.nth(2)).toHaveText('Offer');
+    await expect(options.nth(3)).toHaveText('Rejected');
+  });
+
+  // TC8 - unauthenticated redirect
+  test('TC8 - unauthenticated user cannot access create form', async ({ browser }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await page.goto('/applications/new');
+    await expect(page).toHaveURL('/login');
+    await context.close();
+  });
+
+  // TC11 - buton dezactivat in timpul submitului
+  test('TC11 - submit button is disabled while submitting', async ({ page }) => {
+    await page.getByLabel('Company name').fill('Amazon');
+    await page.getByLabel('Role').fill('DevOps Engineer');
+    await page.getByLabel('Application date').fill('2026-04-14');
+    await page.getByRole('button', { name: 'Save application' }).click();
+
+    await expect(page.getByRole('button', { name: 'Saving...' })).toBeDisabled();
+  });
+
+  // TC13 - aplicatia apare in lista dupa creare
+  test('TC13 - new application appears in list after creation', async ({ page }) => {
+    await page.getByLabel('Company name').fill('Meta');
+    await page.getByLabel('Role').fill('Frontend Developer');
+    await page.getByLabel('Application date').fill('2026-04-14');
+    await page.getByRole('button', { name: 'Save application' }).click();
+
+    await expect(page).toHaveURL('/');
+    await expect(page.getByText('Meta')).toBeVisible();
+    await expect(page.getByText('Frontend Developer')).toBeVisible();
+  });
+});

--- a/MPI-Project/frontend/e2e/dashboard-stats.spec.ts
+++ b/MPI-Project/frontend/e2e/dashboard-stats.spec.ts
@@ -1,0 +1,158 @@
+import { test, expect } from '@playwright/test';
+
+const TIMESTAMP = Date.now();
+const TEST_USER = {
+  fullName: 'Stats Test User',
+  email: `statstest_${TIMESTAMP}@example.com`,
+  password: 'Password123',
+};
+
+const statsSection = (page: import('@playwright/test').Page) =>
+  page.locator('[aria-label="Applications statistics"]');
+
+const statValue = (page: import('@playwright/test').Page, label: string) =>
+  statsSection(page).locator('.applications-stat-card').filter({ hasText: label }).locator('strong');
+
+test.describe('Dashboard Statistics Flow', () => {
+  test.setTimeout(60000);
+
+  test.beforeAll(async ({ browser }, testInfo) => {
+    testInfo.setTimeout(90000);
+    const page = await browser.newPage();
+    // inregistrare
+    await page.goto('/register');
+    await page.getByLabel('Full name').fill(TEST_USER.fullName);
+    await page.getByLabel('Email').fill(TEST_USER.email);
+    await page.getByLabel('Password', { exact: true }).fill(TEST_USER.password);
+    await page.getByLabel('Confirm password').fill(TEST_USER.password);
+    await page.getByRole('button', { name: 'Create account' }).click();
+    await page.locator('.auth-message-success').waitFor();
+    // login
+    await page.goto('/login');
+    await page.getByLabel('Email').fill(TEST_USER.email);
+    await page.getByLabel('Password').fill(TEST_USER.password);
+    await page.getByRole('button', { name: 'Login' }).click();
+    await expect(page).toHaveURL('/');
+    // 2 aplicatii APPLIED
+    for (const company of ['Applied Corp 1', 'Applied Corp 2']) {
+      await page.goto('/applications/new');
+      await page.getByLabel('Company name').fill(company);
+      await page.getByLabel('Role').fill('Developer');
+      await page.getByLabel('Status').selectOption('APPLIED');
+      await page.getByLabel('Application date').fill('2026-04-14');
+      await page.getByRole('button', { name: 'Save application' }).click();
+      await expect(page).toHaveURL('/');
+    }
+    // 1 aplicatie INTERVIEW
+    await page.goto('/applications/new');
+    await page.getByLabel('Company name').fill('Interview Corp');
+    await page.getByLabel('Role').fill('Developer');
+    await page.getByLabel('Status').selectOption('INTERVIEW');
+    await page.getByLabel('Application date').fill('2026-04-14');
+    await page.getByRole('button', { name: 'Save application' }).click();
+    await expect(page).toHaveURL('/');
+    // 1 aplicatie OFFER
+    await page.goto('/applications/new');
+    await page.getByLabel('Company name').fill('Offer Corp');
+    await page.getByLabel('Role').fill('Developer');
+    await page.getByLabel('Status').selectOption('OFFER');
+    await page.getByLabel('Application date').fill('2026-04-14');
+    await page.getByRole('button', { name: 'Save application' }).click();
+    await expect(page).toHaveURL('/');
+    // 1 aplicatie REJECTED
+    await page.goto('/applications/new');
+    await page.getByLabel('Company name').fill('Rejected Corp');
+    await page.getByLabel('Role').fill('Developer');
+    await page.getByLabel('Status').selectOption('REJECTED');
+    await page.getByLabel('Application date').fill('2026-04-14');
+    await page.getByRole('button', { name: 'Save application' }).click();
+    await expect(page).toHaveURL('/');
+    await page.close();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/login');
+    await page.getByLabel('Email').fill(TEST_USER.email);
+    await page.getByLabel('Password').fill(TEST_USER.password);
+    await page.getByRole('button', { name: 'Login' }).click();
+    await expect(page).toHaveURL('/');
+    // asteapta ca statisticile sa se incarce
+    await expect(statValue(page, 'Total applications')).not.toHaveText('...');
+  });
+
+  // TC1 - sectiunea de statistici este vizibila
+  test('TC1 - dashboard statistics section is visible', async ({ page }) => {
+    await expect(statsSection(page)).toBeVisible();
+    await expect(statValue(page, 'Total applications')).toBeVisible();
+    await expect(statValue(page, 'Applied')).toBeVisible();
+    await expect(statValue(page, 'Interview')).toBeVisible();
+    await expect(statValue(page, 'Offer')).toBeVisible();
+    await expect(statValue(page, 'Rejected')).toBeVisible();
+  });
+
+  // TC2 - totalul reflecta numarul corect de aplicatii
+  test('TC2 - total count reflects number of created applications', async ({ page }) => {
+    await expect(statValue(page, 'Total applications')).toHaveText('5');
+  });
+
+  // TC3 - contoarele per status sunt corecte
+  test('TC3 - per-status counts are correct', async ({ page }) => {
+    await expect(statValue(page, 'Applied')).toHaveText('2');
+    await expect(statValue(page, 'Interview')).toHaveText('1');
+    await expect(statValue(page, 'Offer')).toHaveText('1');
+    await expect(statValue(page, 'Rejected')).toHaveText('1');
+  });
+
+  // TC4 - statisticile se actualizeaza dupa adaugarea unei aplicatii
+  test('TC4 - stats update after adding a new application', async ({ page }) => {
+    await page.goto('/applications/new');
+    await page.getByLabel('Company name').fill('New Applied Corp');
+    await page.getByLabel('Role').fill('Developer');
+    await page.getByLabel('Status').selectOption('APPLIED');
+    await page.getByLabel('Application date').fill('2026-04-14');
+    await page.getByRole('button', { name: 'Save application' }).click();
+    await expect(page).toHaveURL('/');
+
+    await expect(statValue(page, 'Total applications')).not.toHaveText('...');
+    await expect(statValue(page, 'Total applications')).toHaveText('6');
+    await expect(statValue(page, 'Applied')).toHaveText('3');
+  });
+
+  // TC5 - statisticile se actualizeaza dupa stergerea unei aplicatii
+  test('TC5 - stats update after deleting an application', async ({ page }) => {
+    const initialTotal = await statValue(page, 'Total applications').textContent();
+    const expectedTotal = String(Number(initialTotal) - 1);
+
+    page.on('dialog', (dialog) => dialog.accept());
+    await page.getByRole('button', { name: 'Delete' }).first().click();
+    await expect(statValue(page, 'Total applications')).not.toHaveText('...');
+    await expect(statValue(page, 'Total applications')).toHaveText(expectedTotal);
+  });
+
+  // TC6 - user nou fara aplicatii vede toate statisticile = 0
+  test('TC6 - new user with no applications sees all stats as zero', async ({ browser }) => {
+    const emptyEmail = `statsempty_${TIMESTAMP}@example.com`;
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await page.goto('/register');
+    await page.getByLabel('Full name').fill('Stats Empty User');
+    await page.getByLabel('Email').fill(emptyEmail);
+    await page.getByLabel('Password', { exact: true }).fill('Password123');
+    await page.getByLabel('Confirm password').fill('Password123');
+    await page.getByRole('button', { name: 'Create account' }).click();
+    await page.locator('.auth-message-success').waitFor();
+    await page.goto('/login');
+    await page.getByLabel('Email').fill(emptyEmail);
+    await page.getByLabel('Password').fill('Password123');
+    await page.getByRole('button', { name: 'Login' }).click();
+    await expect(page).toHaveURL('/');
+    await expect(statValue(page, 'Total applications')).not.toHaveText('...');
+
+    await expect(statValue(page, 'Total applications')).toHaveText('0');
+    await expect(statValue(page, 'Applied')).toHaveText('0');
+    await expect(statValue(page, 'Interview')).toHaveText('0');
+    await expect(statValue(page, 'Offer')).toHaveText('0');
+    await expect(statValue(page, 'Rejected')).toHaveText('0');
+    await context.close();
+  });
+});

--- a/MPI-Project/frontend/e2e/delete-application.spec.ts
+++ b/MPI-Project/frontend/e2e/delete-application.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect } from '@playwright/test';
+
+const TIMESTAMP = Date.now();
+const TEST_USER = {
+  fullName: 'Delete Test User',
+  email: `deletetest_${TIMESTAMP}@example.com`,
+  password: 'Password123',
+};
+
+test.describe('Delete Application Flow', () => {
+  test.beforeAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    await page.goto('/register');
+    await page.getByLabel('Full name').fill(TEST_USER.fullName);
+    await page.getByLabel('Email').fill(TEST_USER.email);
+    await page.getByLabel('Password', { exact: true }).fill(TEST_USER.password);
+    await page.getByLabel('Confirm password').fill(TEST_USER.password);
+    await page.getByRole('button', { name: 'Create account' }).click();
+    await page.locator('.auth-message-success').waitFor();
+    await page.close();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/login');
+    await page.getByLabel('Email').fill(TEST_USER.email);
+    await page.getByLabel('Password').fill(TEST_USER.password);
+    await page.getByRole('button', { name: 'Login' }).click();
+    await expect(page).toHaveURL('/');
+    // cream o aplicatie proaspata pentru fiecare test
+    await page.goto('/applications/new');
+    await page.getByLabel('Company name').fill('To Delete Corp');
+    await page.getByLabel('Role').fill('Tester');
+    await page.getByLabel('Application date').fill('2026-04-14');
+    await page.getByRole('button', { name: 'Save application' }).click();
+    await expect(page).toHaveURL('/');
+  });
+
+  // TC2 - dialog de confirmare apare
+  test('TC2 - confirmation dialog appears on delete', async ({ page }) => {
+    let dialogAppeared = false;
+    page.on('dialog', async (dialog) => {
+      dialogAppeared = true;
+      await dialog.dismiss();
+    });
+
+    await page.getByRole('button', { name: 'Delete' }).first().click();
+    expect(dialogAppeared).toBe(true);
+  });
+
+  // TC3 - cancel deletion - aplicatia ramane
+  test('TC3 - cancel deletion keeps application in list', async ({ page }) => {
+    page.on('dialog', (dialog) => dialog.dismiss());
+
+    await page.getByRole('button', { name: 'Delete' }).first().click();
+    await expect(page.getByRole('cell', { name: 'To Delete Corp' }).first()).toBeVisible();
+  });
+
+  // TC4 - confirmare stergere - aplicatia dispare
+  test('TC4 - confirm deletion removes application from list', async ({ page }) => {
+    page.on('dialog', (dialog) => dialog.accept());
+
+    await page.getByRole('button', { name: 'Delete' }).first().waitFor();
+    const initialCount = await page.getByRole('button', { name: 'Delete' }).count();
+    await page.getByRole('button', { name: 'Delete' }).first().click();
+    await expect(page.getByRole('button', { name: 'Delete' })).toHaveCount(initialCount - 1);
+  });
+
+  // TC11 - stergere ultima aplicatie afiseaza empty state
+  test('TC11 - deleting last application shows empty state', async ({ page }) => {
+    page.on('dialog', (dialog) => dialog.accept());
+
+    await expect(page.getByRole('button', { name: 'Delete' }).first()).toBeVisible();
+    let deleteCount = await page.getByRole('button', { name: 'Delete' }).count();
+
+    while (deleteCount > 0) {
+      await page.getByRole('button', { name: 'Delete' }).first().click();
+      deleteCount--;
+      if (deleteCount > 0) {
+        await expect(page.getByRole('button', { name: 'Delete' })).toHaveCount(deleteCount);
+      } else {
+        await expect(page.locator('.applications-state')).toBeVisible();
+      }
+    }
+
+    await expect(page.locator('.applications-state')).toContainText('No applications yet');
+  });
+});

--- a/MPI-Project/frontend/e2e/edit-application.spec.ts
+++ b/MPI-Project/frontend/e2e/edit-application.spec.ts
@@ -1,0 +1,147 @@
+import { test, expect } from '@playwright/test';
+
+const TIMESTAMP = Date.now();
+const TEST_USER = {
+  fullName: 'Edit Test User',
+  email: `edittest_${TIMESTAMP}@example.com`,
+  password: 'Password123',
+};
+
+test.describe('Edit Application Flow', () => {
+  test.beforeAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    await page.goto('/register');
+    await page.getByLabel('Full name').fill(TEST_USER.fullName);
+    await page.getByLabel('Email').fill(TEST_USER.email);
+    await page.getByLabel('Password', { exact: true }).fill(TEST_USER.password);
+    await page.getByLabel('Confirm password').fill(TEST_USER.password);
+    await page.getByRole('button', { name: 'Create account' }).click();
+    await page.locator('.auth-message-success').waitFor();
+    await page.goto('/login');
+    await page.getByLabel('Email').fill(TEST_USER.email);
+    await page.getByLabel('Password').fill(TEST_USER.password);
+    await page.getByRole('button', { name: 'Login' }).click();
+    await expect(page).toHaveURL('/');
+    await page.goto('/applications/new');
+    await page.getByLabel('Company name').fill('Google');
+    await page.getByLabel('Role').fill('Software Engineer');
+    await page.getByLabel('Status').selectOption('APPLIED');
+    await page.getByLabel('Application date').fill('2026-04-14');
+    await page.getByRole('button', { name: 'Save application' }).click();
+    await expect(page).toHaveURL('/');
+    await page.close();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/login');
+    await page.getByLabel('Email').fill(TEST_USER.email);
+    await page.getByLabel('Password').fill(TEST_USER.password);
+    await page.getByRole('button', { name: 'Login' }).click();
+    await expect(page).toHaveURL('/');
+    await page.getByRole('link', { name: 'Edit' }).first().click();
+    await expect(page).toHaveURL(/\/applications\/.*\/edit/);
+    // asteapta ca datele sa se incarce din API
+    await expect(page.getByLabel('Company name')).not.toHaveValue('');
+  });
+
+  // TC1 - pagina se incarca cu campurile pre-completate
+  test('TC1 - edit page loads with pre-filled data', async ({ page }) => {
+    await expect(page.getByLabel('Company name')).toHaveValue('Google');
+    await expect(page.getByLabel('Role')).toHaveValue('Software Engineer');
+    await expect(page.getByLabel('Status')).toHaveValue('APPLIED');
+  });
+
+  // TC2 - update cu succes redirecteaza la lista
+  test('TC2 - successful update redirects to applications list', async ({ page }) => {
+    await page.getByLabel('Company name').fill('Google Updated');
+    await page.getByRole('button', { name: 'Save changes' }).click();
+
+    await expect(page).toHaveURL('/');
+  });
+
+  // TC3 - update partial (doar status)
+  test('TC3 - partial update changes only modified field', async ({ page }) => {
+    // retine URL-ul aplicatiei curente
+    const editUrl = page.url();
+    await page.getByLabel('Status').selectOption('INTERVIEW');
+    await page.getByRole('button', { name: 'Save changes' }).click();
+
+    await expect(page).toHaveURL('/');
+    // redeschide aceeasi aplicatie folosind URL-ul retinut
+    await page.goto(editUrl);
+    await expect(page).toHaveURL(/\/applications\/.*\/edit/);
+    await expect(page.getByLabel('Company name')).not.toHaveValue('');
+    await expect(page.locator('select#status')).toHaveValue('INTERVIEW');
+  });
+
+  // TC11 - buton dezactivat in timpul submitului
+  test('TC11 - submit button is disabled while submitting', async ({ page }) => {
+    await page.route('**/applications/**', async (route) => {
+      await new Promise((r) => setTimeout(r, 1000));
+      await route.continue();
+    });
+    await page.getByRole('button', { name: 'Save changes' }).click();
+    await expect(page.getByRole('button', { name: 'Saving...' })).toBeDisabled();
+  });
+
+  // NOTE1 - adauga o nota
+  test('NOTE1 - add note appears in notes list', async ({ page }) => {
+    await page.locator('textarea').first().fill('Interview scheduled for next week');
+    await page.getByRole('button', { name: 'Add note' }).click();
+
+    await expect(page.getByText('Interview scheduled for next week')).toBeVisible();
+  });
+
+  // NOTE2 - editeaza o nota existenta
+  test('NOTE2 - edit note updates content', async ({ page }) => {
+    await page.locator('textarea').first().fill('Original note content');
+    await page.getByRole('button', { name: 'Add note' }).click();
+    await expect(page.getByText('Original note content')).toBeVisible();
+
+    const noteToEdit = page.locator('.notes-item').filter({ hasText: 'Original note content' });
+    await noteToEdit.getByRole('button', { name: 'Edit note' }).click();
+    const editTextarea = noteToEdit.locator('textarea');
+    await editTextarea.waitFor({ state: 'visible' });
+    await editTextarea.click({ clickCount: 3 });
+    await page.keyboard.type('Updated note content');
+    await page.getByRole('button', { name: 'Save note' }).click();
+
+    await expect(page.getByText('Updated note content')).toBeVisible();
+    await expect(page.locator('.notes-list').getByText('Original note content')).not.toBeVisible();
+  });
+
+  // NOTE3 - sterge o nota
+  test('NOTE3 - delete note removes it from list', async ({ page }) => {
+    await page.locator('textarea').first().fill('Note to delete');
+    await page.getByRole('button', { name: 'Add note' }).click();
+    await expect(page.getByText('Note to delete')).toBeVisible();
+
+    page.on('dialog', (dialog) => dialog.accept());
+    await page.locator('.notes-item').filter({ hasText: 'Note to delete' }).getByRole('button', { name: 'Delete note' }).click();
+
+    await expect(page.locator('.notes-item').filter({ hasText: 'Note to delete' })).not.toBeVisible();
+  });
+
+  // NOTE4 - cancel edit nota
+  test('NOTE4 - cancel edit note keeps original content', async ({ page }) => {
+    await page.locator('textarea').first().fill('Note to keep');
+    await page.getByRole('button', { name: 'Add note' }).click();
+    await expect(page.getByText('Note to keep')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Edit note' }).first().click();
+    await page.locator('.notes-list textarea').fill('Changed content');
+    await page.getByRole('button', { name: 'Cancel' }).click();
+
+    await expect(page.getByText('Note to keep')).toBeVisible();
+    await expect(page.locator('.notes-list p').filter({ hasText: 'Changed content' })).not.toBeVisible();
+  });
+
+  // TC9 - unauthenticated redirect
+  test('TC9 - unauthenticated user cannot access edit page', async ({ browser }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await page.goto('/applications/some-id/edit');
+    await expect(page).toHaveURL('/login');
+    await context.close();
+  });
+});

--- a/MPI-Project/frontend/e2e/login.spec.ts
+++ b/MPI-Project/frontend/e2e/login.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect } from '@playwright/test';
+
+const TIMESTAMP = Date.now();
+const TEST_USER = {
+  fullName: 'Login Test User',
+  email: `logintest_${TIMESTAMP}@example.com`,
+  password: 'Password123',
+};
+
+test.describe('Login Flow', () => {
+  // inregistram userul inainte de toate testele
+  test.beforeAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    await page.goto('/register');
+    await page.getByLabel('Full name').fill(TEST_USER.fullName);
+    await page.getByLabel('Email').fill(TEST_USER.email);
+    await page.getByLabel('Password', { exact: true }).fill(TEST_USER.password);
+    await page.getByLabel('Confirm password').fill(TEST_USER.password);
+    await page.getByRole('button', { name: 'Create account' }).click();
+    await page.locator('.auth-message-success').waitFor();
+    await page.close();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/login');
+  });
+
+  // TC1
+  test('TC1 - login page loads with all required fields', async ({ page }) => {
+    await expect(page.getByLabel('Email')).toBeVisible();
+    await expect(page.getByLabel('Password')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Login' })).toBeVisible();
+  });
+
+  // TC2
+  test('TC2 - successful login redirects to dashboard', async ({ page }) => {
+    await page.getByLabel('Email').fill(TEST_USER.email);
+    await page.getByLabel('Password').fill(TEST_USER.password);
+    await page.getByRole('button', { name: 'Login' }).click();
+
+    await expect(page).toHaveURL('/');
+  });
+
+  // TC5
+  test('TC5 - incorrect password shows error', async ({ page }) => {
+    await page.getByLabel('Email').fill(TEST_USER.email);
+    await page.getByLabel('Password').fill('WrongPassword123');
+    await page.getByRole('button', { name: 'Login' }).click();
+
+    await expect(page.locator('.auth-message-error')).toBeVisible();
+  });
+
+  // TC6
+  test('TC6 - non-existent email shows error', async ({ page }) => {
+    await page.getByLabel('Email').fill('nonexistent@example.com');
+    await page.getByLabel('Password').fill('Password123');
+    await page.getByRole('button', { name: 'Login' }).click();
+
+    await expect(page.locator('.auth-message-error')).toBeVisible();
+  });
+
+  // TC8
+  test('TC8 - password field is masked by default', async ({ page }) => {
+    await expect(page.getByLabel('Password')).toHaveAttribute('type', 'password');
+  });
+
+  // TC11
+  test('TC11 - submit button is disabled while submitting', async ({ page }) => {
+    await page.getByLabel('Email').fill(TEST_USER.email);
+    await page.getByLabel('Password').fill(TEST_USER.password);
+    await page.getByRole('button', { name: 'Login' }).click();
+
+    await expect(page.getByRole('button', { name: 'Logging in...' })).toBeDisabled();
+  });
+
+  // TC12
+  test('TC12 - unauthenticated user is redirected to login', async ({ page }) => {
+    await page.goto('/');
+    await expect(page).toHaveURL('/login');
+  });
+});

--- a/MPI-Project/frontend/e2e/register.spec.ts
+++ b/MPI-Project/frontend/e2e/register.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect } from '@playwright/test';
+
+const TIMESTAMP = Date.now();
+const TEST_USER = {
+  fullName: 'Test User',
+  email: `testuser_${TIMESTAMP}@example.com`,
+  password: 'Password123',
+};
+
+test.describe('Register Flow', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/register');
+  });
+
+  // TC1 - pagina se incarca cu toate campurile vizibile
+  test('TC1 - registration page loads with all required fields', async ({ page }) => {
+    await expect(page.getByLabel('Full name')).toBeVisible();
+    await expect(page.getByLabel('Email')).toBeVisible();
+    await expect(page.getByLabel('Password', { exact: true })).toBeVisible();
+    await expect(page.getByLabel('Confirm password')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Create account' })).toBeVisible();
+  });
+
+  // TC2 - inregistrare cu succes afiseaza mesaj de confirmare
+  test('TC2 - successful registration shows confirmation message', async ({ page }) => {
+    await page.getByLabel('Full name').fill(TEST_USER.fullName);
+    await page.getByLabel('Email').fill(TEST_USER.email);
+    await page.getByLabel('Password', { exact: true }).fill(TEST_USER.password);
+    await page.getByLabel('Confirm password').fill(TEST_USER.password);
+    await page.getByRole('button', { name: 'Create account' }).click();
+
+    await expect(page.locator('.auth-message-success')).toBeVisible();
+  });
+
+  // TC7 - email deja existent afiseaza eroare
+  test('TC7 - duplicate email shows error message', async ({ page }) => {
+    const duplicateEmail = `duplicate_${TIMESTAMP}@example.com`;
+
+    // prima inregistrare
+    await page.getByLabel('Full name').fill(TEST_USER.fullName);
+    await page.getByLabel('Email').fill(duplicateEmail);
+    await page.getByLabel('Password', { exact: true }).fill(TEST_USER.password);
+    await page.getByLabel('Confirm password').fill(TEST_USER.password);
+    await page.getByRole('button', { name: 'Create account' }).click();
+    await expect(page.locator('.auth-message-success')).toBeVisible();
+
+    // a doua incercare cu acelasi email
+    await page.getByLabel('Full name').fill(TEST_USER.fullName);
+    await page.getByLabel('Email').fill(duplicateEmail);
+    await page.getByLabel('Password', { exact: true }).fill(TEST_USER.password);
+    await page.getByLabel('Confirm password').fill(TEST_USER.password);
+    await page.getByRole('button', { name: 'Create account' }).click();
+
+    await expect(page.locator('.auth-message-error')).toBeVisible();
+  });
+
+  // TC9 - campurile de parola sunt mascate implicit
+  test('TC9 - password fields are masked by default', async ({ page }) => {
+    await expect(page.getByLabel('Password', { exact: true })).toHaveAttribute('type', 'password');
+    await expect(page.getByLabel('Confirm password')).toHaveAttribute('type', 'password');
+  });
+
+  // TC11 - butonul e dezactivat in timpul submitului
+  test('TC11 - submit button is disabled while submitting', async ({ page }) => {
+    await page.getByLabel('Full name').fill(TEST_USER.fullName);
+    await page.getByLabel('Email').fill(`submit_${TIMESTAMP}@example.com`);
+    await page.getByLabel('Password', { exact: true }).fill(TEST_USER.password);
+    await page.getByLabel('Confirm password').fill(TEST_USER.password);
+
+    await page.getByRole('button', { name: 'Create account' }).click();
+    await expect(page.getByRole('button', { name: 'Creating account...' })).toBeDisabled();
+  });
+
+  // TC12 - campurile retin valorile dupa eroare (passwords mismatch)
+  test('TC12 - input fields retain values after validation error', async ({ page }) => {
+    await page.getByLabel('Full name').fill('Test User');
+    await page.getByLabel('Email').fill('retain@example.com');
+    await page.getByLabel('Password', { exact: true }).fill('Password123');
+    await page.getByLabel('Confirm password').fill('Different123');
+    await page.getByRole('button', { name: 'Create account' }).click();
+
+    await expect(page.locator('.auth-message-error')).toBeVisible();
+    await expect(page.getByLabel('Full name')).toHaveValue('Test User');
+    await expect(page.getByLabel('Email')).toHaveValue('retain@example.com');
+  });
+});

--- a/MPI-Project/frontend/package-lock.json
+++ b/MPI-Project/frontend/package-lock.json
@@ -15,6 +15,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@playwright/test": "^1.59.1",
         "@types/node": "^24.12.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -588,6 +589,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -2771,6 +2788,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/MPI-Project/frontend/package.json
+++ b/MPI-Project/frontend/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@playwright/test": "^1.59.1",
     "@types/node": "^24.12.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/MPI-Project/frontend/playwright.config.ts
+++ b/MPI-Project/frontend/playwright.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// import dotenv from 'dotenv';
+// import path from 'path';
+// dotenv.config({ path: path.resolve(__dirname, '.env') });
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:5173',
+    trace: 'on-first-retry',
+    headless: true,
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/MPI-Project/frontend/tsconfig.node.json
+++ b/MPI-Project/frontend/tsconfig.node.json
@@ -20,5 +20,5 @@
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "playwright.config.ts"]
 }


### PR DESCRIPTION
Summary
Added Playwright E2E tests for the main auth and applications flows.

Covered flows
- register
- login
- create application
- edit application
- dashboard statistics
- notes interactions

Related to #30
Related to #10
